### PR TITLE
removes cmd to rm config.ini.php which is no longer generated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN git clone https://github.com/heroku/heroku-buildpack-php.git /tmp/php-pack -
 
 COPY . /app
 RUN bash -l /tmp/php-pack/bin/compile /app /tmp/cache /app/.env
-RUN rm vendor/piwik/piwik/config/config.ini.php
 RUN rm -rf /tmp/cache
 RUN rm -rf /tmp/php-pack
 


### PR DESCRIPTION
Originally the composer.json file contained a script command to use sed to
place the DB variables into a config.ini.php after copying the file.
That script was removed in 641bee0
