### PR TITLE
INCOMPLETE:  Configuring database via env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://github.com/heroku/heroku-buildpack-php.git /tmp/php-pack -
 
 COPY . /app
 RUN bash -l /tmp/php-pack/bin/compile /app /tmp/cache /app/.env
-RUN rm vendor/piwik/piwik/config/config.ini.php
+#RUN rm vendor/piwik/piwik/config/config.ini.php
 RUN rm -rf /tmp/cache
 RUN rm -rf /tmp/php-pack
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
         "ext-gd": "*",
         "ext-apcu": "*"
     },
-      "require-dev": {
-    "heroku/heroku-buildpack-php": "*"}
+    "require-dev": {
+        "heroku/heroku-buildpack-php": "*"},
+    "scripts": {
+        "compile": [
+              "cp config.ini.php vendor/piwik/piwik/config/config.ini.php"
+        ]
+    }
 }

--- a/config.ini.php
+++ b/config.ini.php
@@ -1,37 +1,48 @@
 ; <?php exit; ?> DO NOT REMOVE THIS LINE
 ; file automatically generated or modified by Piwik; you can manually override the default values in global.ini.php by redefining them in this file.
-<?php 
-  // This will parse the values from DATABASE_URL if present (true on dokku, 
-  // once you link a database to your app
-  if ($_ENV['DATABASE_URL'] != null) {
-    $u = parse_url($_ENV['DATABASE_URL']);
+;<?php 
+;  // This will parse the values from DATABASE_URL if present (true on dokku, 
+;  // once you link a database to your app
+;  if ($_ENV['DATABASE_URL'] != null) {
+;    $u = parse_url($_ENV['DATABASE_URL']);
+;
+;    $db_host = $u['host'];
+;    $db_user= $u['user'];
+;    $db_pass= $u['pass'];
+;    $db_name = $u['path'];
+;    $db_port = $u['port'];
+;  }
+;  else {
+;    $db_host = $_ENV['DB_HOST'];
+;    $db_user= $_ENV['DB_USERNAME'];
+;    $db_pass= $_ENV['DB_PASSWORD'];
+;    $db_name = $_ENV['DB_NAME'];
+;    $db_port = $_ENV['DB__PORT'];
+;  }
+;?>
+;
+;[database]
+;host = "<?php echo $db_host; ?>"
+;username = "<?php echo $db_user; ?>"
+;password = "<?php echo $db_pass; ?>"
+;dbname = "<?php echo $db_name; ?>"
+;tables_prefix = "<?php echo $_ENV['DB_PREFIX']; ?>"
+;port = "<?php echo $db_port; ?>"
+;charset = "utf8"
 
-    $db_host = $u['host'];
-    $db_user= $u['user'];
-    $db_pass= $u['pass'];
-    $db_name = $u['path'];
-    $db_port = $u['port'];
-  }
-  else {
-    $db_host = $_ENV['DB_HOST'];
-    $db_user= $_ENV['DB_USERNAME'];
-    $db_pass= $_ENV['DB_PASSWORD'];
-    $db_name = $_ENV['DB_NAME'];
-    $db_port = $_ENV['DB__PORT'];
-  }
-?>
+;mysql:b57155eb5cd509af@dokku-mysql-piwik-db:3306/piwik-db
 
 [database]
-host = "<?php echo $db_host; ?>"
-username = "<?php echo $db_user; ?>"
-password = "<?php echo $db_pass; ?>"
-dbname = "<?php echo $db_name; ?>"
-tables_prefix = "<?php echo $_ENV['DB_PREFIX']; ?>"
-port = "<?php echo $db_port; ?>"
+host = dokku-mysql-piwik-db
+username = ENV[DB_USERNAME]
+password = ENV[DB_PASSWORD]
+dbname = ENV[DB_NAME]
+tables_prefix = 
+port = ENV[DB_PORT]
 charset = "utf8"
 
 [General]
-salt = "<?php $_ENV['SECRET'] ?>"
+salt = cidjdkfjldcn
 session_save_handler = dbtable
 
 [PluginsInstalled]

--- a/config.ini.php
+++ b/config.ini.php
@@ -1,12 +1,33 @@
 ; <?php exit; ?> DO NOT REMOVE THIS LINE
 ; file automatically generated or modified by Piwik; you can manually override the default values in global.ini.php by redefining them in this file.
+<?php 
+  // This will parse the values from DATABASE_URL if present (true on dokku, 
+  // once you link a database to your app
+  if ($_ENV['DATABASE_URL'] != null) {
+    $u = parse_url($_ENV['DATABASE_URL']);
+
+    $db_host = $u['host'];
+    $db_user= $u['user'];
+    $db_pass= $u['pass'];
+    $db_name = $u['path'];
+    $db_port = $u['port'];
+  }
+  else {
+    $db_host = $_ENV['DB_HOST'];
+    $db_user= $_ENV['DB_USERNAME'];
+    $db_pass= $_ENV['DB_PASSWORD'];
+    $db_name = $_ENV['DB_NAME'];
+    $db_port = $_ENV['DB__PORT'];
+  }
+?>
+
 [database]
-host = <?php $_ENV['DB_HOST']; ?>
-username = <?php $_ENV['DB_USERNAME']; ?>
-password = <?php $_ENV['DB_PASSWORD']; ?>
-dbname = <?php $_ENV['DB_NAME']; ?>
+host = <?php $db_host; ?>
+username = <?php $db_user; ?>
+password = <?php $db_pass; ?>
+dbname = <?php $db_name; ?>
 tables_prefix = <?php $_ENV['DB_PREFIX']; ?>
-port = <?php $_ENV['DB__PORT']; ?>
+port = <?php $db_port; ?>
 charset = "utf8"
 
 [General]

--- a/config.ini.php
+++ b/config.ini.php
@@ -31,7 +31,7 @@ port = <?php $db_port; ?>
 charset = "utf8"
 
 [General]
-salt = "#SECRET_TOKEN"
+salt = "<?php $_ENV['SECRET'] ?>"
 session_save_handler = dbtable
 
 [PluginsInstalled]

--- a/config.ini.php
+++ b/config.ini.php
@@ -22,12 +22,12 @@
 ?>
 
 [database]
-host = <?php $db_host; ?>
-username = <?php $db_user; ?>
-password = <?php $db_pass; ?>
-dbname = <?php $db_name; ?>
-tables_prefix = <?php $_ENV['DB_PREFIX']; ?>
-port = <?php $db_port; ?>
+host = "<?php echo $db_host; ?>"
+username = "<?php echo $db_user; ?>"
+password = "<?php echo $db_pass; ?>"
+dbname = "<?php echo $db_name; ?>"
+tables_prefix = "<?php echo $_ENV['DB_PREFIX']; ?>"
+port = "<?php echo $db_port; ?>"
 charset = "utf8"
 
 [General]


### PR DESCRIPTION
So this is as far as I've gotten.  It will deploy to dokku and heroku, but when you open the app in a browser you get an error message:

```
An error occurred

Unable to read INI file {/app/vendor/piwik/piwik/config/config.ini.php}: Syntax error in INI configuration: Your host may have disabled parse_ini_file().
```

The resulting config.ini.php file looks something like this...

```
; <?php exit; ?> DO NOT REMOVE THIS LINE
; file automatically generated or modified by Piwik; you can manually override the default values in global.ini.php by redefining them in this file.
<?php 
  // This will parse the values from DATABASE_URL if present (true on dokku, 
  // once you link a database to your app
  if ($_ENV['DATABASE_URL'] != null) {
    $u = parse_url($_ENV['DATABASE_URL']);

    $db_host = $u['host'];
    $db_user= $u['user'];
    $db_pass= $u['pass'];
    $db_name = $u['path'];
    $db_port = $u['port'];
  }
  else {
    $db_host = $_ENV['DB_HOST'];
    $db_user= $_ENV['DB_USERNAME'];
    $db_pass= $_ENV['DB_PASSWORD'];
    $db_name = $_ENV['DB_NAME'];
    $db_port = $_ENV['DB__PORT'];
  }
?>

[database]
host = "<?php echo $db_host; ?>"
username = "<?php echo $db_user; ?>"
password = "<?php echo $db_pass; ?>"
dbname = "<?php echo $db_name; ?>"
tables_prefix = "<?php echo $_ENV['DB_PREFIX']; ?>"
port = "<?php echo $db_port; ?>"
charset = "utf8"

[General]
salt = "<?php $_ENV['SECRET'] ?>"
session_save_handler = dbtable
```

Any ideas as?  Was it presumptuous for me to assume php could be interpreted in that file?  I'm have trouble finding example config files online, and am still pretty new to configuring piwik, let alone doing so in a 12factor manor.  
